### PR TITLE
Add thanks to supporters

### DIFF
--- a/_data/thanks.yml
+++ b/_data/thanks.yml
@@ -1,0 +1,4 @@
+cmok: Komяpa
+vial: Komяpa
+konqi: Freerk Ohling
+katie: Freerk Ohling

--- a/_data/urls.yml
+++ b/_data/urls.yml
@@ -101,8 +101,10 @@ isps:
   dotsrc.org: http://dotsrc.org/
   EUserv: http://www.euserv.com/
   Exonetric: http://www.exonetric.com/
+  Freerk Ohling: https://www.ohling.org/
   Hetzner: https://www.hetzner.de/
   Jump Networks: http://www.jump.net.uk/
+  Komяpa: http://komzpa.net/
   LyonIX: http://www.lyonix.net/
   NCHC: http://www.nchc.org.tw/en/
   OSUOSL: http://osuosl.org/

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -6,6 +6,7 @@
 
     <nav class="site-nav">
       <a class="page-link" href="{{ site.baseurl }}/about/">About</a>
+      <a class="page-link" href="{{ site.baseurl }}/thanks/">Thanks</a>
     </nav>
 
   </div>

--- a/_layouts/server.md
+++ b/_layouts/server.md
@@ -113,3 +113,7 @@ layout: default
 
 {% endfor %}
 {% endif %}
+
+## Thanks
+
+Many thanks to {{ page.thanks_to | linkify: 'isps' }} for supporting this server.

--- a/_plugins/linkify_filter.rb
+++ b/_plugins/linkify_filter.rb
@@ -9,6 +9,10 @@ module Jekyll
         input
       end
     end
+
+    def linkify_all(input, group)
+      input.map {|i| linkify(i, group) }
+    end
   end
 end
 

--- a/_plugins/recent.rb
+++ b/_plugins/recent.rb
@@ -1,0 +1,15 @@
+module Jekyll
+  module RecentFilter
+    def recent(nodes)
+      # require activity in the last 30 days
+      cutoff = Time.now - (30 * 24 * 60 * 60)
+
+      nodes.select do |node|
+        time = node['automatic']['ohai_time']
+        time > cutoff.to_f
+      end
+    end
+  end
+end
+
+Liquid::Template.register_filter(Jekyll::RecentFilter)

--- a/_plugins/server_generator.rb
+++ b/_plugins/server_generator.rb
@@ -1,7 +1,5 @@
 module Jekyll
   class ServerPage < Page
-    include Jekyll::ThanksToFilter
-
     def initialize(site, base, dir, attributes)
       @site = site
       @base = base
@@ -13,7 +11,7 @@ module Jekyll
       data['server'] = extract_details(attributes['automatic'])
       data['title'] = attributes['name']
       data['roles'] = attributes['automatic']['roles']
-      data['thanks_to'] = thanks_to(attributes)
+      data['thanks_to'] = ThanksTo::thanks_to(attributes, @site)
     end
 
     private

--- a/_plugins/server_generator.rb
+++ b/_plugins/server_generator.rb
@@ -1,5 +1,7 @@
 module Jekyll
   class ServerPage < Page
+    include Jekyll::ThanksToFilter
+
     def initialize(site, base, dir, attributes)
       @site = site
       @base = base
@@ -11,6 +13,7 @@ module Jekyll
       data['server'] = extract_details(attributes['automatic'])
       data['title'] = attributes['name']
       data['roles'] = attributes['automatic']['roles']
+      data['thanks_to'] = thanks_to(attributes)
     end
 
     private

--- a/_plugins/thanks_to_filter.rb
+++ b/_plugins/thanks_to_filter.rb
@@ -1,3 +1,23 @@
+class ThanksTo
+  def self.thanks_to(node, site)
+    node_name = node['name'].split('.')[0]
+    roles = node['automatic']['roles']
+    thanks_override = site.data['thanks']
+
+    if roles.include? "ic"
+      "Imperial College London"
+    elsif roles.include? "ucl"
+      "University College London"
+    elsif roles.include? "bytemark"
+      "Bytemark"
+    elsif thanks_override.has_key? node_name
+      thanks_override[node_name]
+    else
+      node['default']['hosted_by']
+    end
+  end
+end
+
 module Jekyll
   module ThanksToFilter
     def thanks_to(node)
@@ -5,22 +25,7 @@ module Jekyll
         return node.map {|n| thanks_to(n)}
       end
 
-      node_name = node['name'].split('.')[0]
-      roles = node['automatic']['roles']
-      site = @context.nil? ? @site : @context.registers[:site]
-      thanks_override = site.data['thanks']
-
-      if roles.include? "ic"
-        "Imperial College London"
-      elsif roles.include? "ucl"
-        "University College London"
-      elsif roles.include? "bytemark"
-        "Bytemark"
-      elsif thanks_override.has_key? node_name
-        thanks_override[node_name]
-      else
-        node['default']['hosted_by']
-      end
+      ThanksTo::thanks_to(node, @context.registers[:site])
     end
   end
 end

--- a/_plugins/thanks_to_filter.rb
+++ b/_plugins/thanks_to_filter.rb
@@ -1,0 +1,28 @@
+module Jekyll
+  module ThanksToFilter
+    def thanks_to(node)
+      if node.is_a? Array
+        return node.map {|n| thanks_to(n)}
+      end
+
+      node_name = node['name'].split('.')[0]
+      roles = node['automatic']['roles']
+      site = @context.nil? ? @site : @context.registers[:site]
+      thanks_override = site.data['thanks']
+
+      if roles.include? "ic"
+        "Imperial College London"
+      elsif roles.include? "ucl"
+        "University College London"
+      elsif roles.include? "bytemark"
+        "Bytemark"
+      elsif thanks_override.has_key? node_name
+        thanks_override[node_name]
+      else
+        node['default']['hosted_by']
+      end
+    end
+  end
+end
+
+Liquid::Template.register_filter(Jekyll::ThanksToFilter)

--- a/thanks.md
+++ b/thanks.md
@@ -1,0 +1,25 @@
+---
+layout: page
+title: Thanks
+permalink: /thanks/
+---
+
+{% assign nodes = site.data.nodes.rows %}
+
+Hosting OpenStreetMap wouldn't be possible without the support of many people and organisations around the world who donate their time, hosting space or hardware to help us. We would like to thank all of these donors for their generosity and support.
+
+## University College London
+
+We would like to thank [University College London](http://www.ucl.ac.uk/)'s [Bartlett centre](http://www.bartlett.ucl.ac.uk/) for their many years of support. They have been supporting OpenStreetMap since its beginning and we are very grateful.
+
+## Bytemark
+
+We would like to thank [Bytemark](https://www.bytemark.co.uk/) for their many years of support. They have been extremely helpful to us in moments of dire need, and we are very grateful.
+
+## Imperial College London
+
+We would like to thank [Imperial College London](http://www.imperial.ac.uk/) for their many years of support and donations.
+
+## And many others...
+
+Many other people and organisations support OpenStreetMap, and we wouldn't be able to do all the things that we do without their help. Our thanks go to {{ nodes | recent | thanks_to | sort | uniq | linkify_all: 'isps' | join: ", " }} and everyone else who contributes to making OpenStreetMap.


### PR DESCRIPTION
Adds a "thanks" page for all the known supporters, where it's possible to derive that information from the OHAI node. Also adds a "thank-you" at the bottom of each server page.

This is probably done in the most hacky and awful way, so I apologise in advance. If there's a more Jekyll-y way that things should be done, please point it out.
