### PR TITLE
Fix munin links

### DIFF
--- a/index.md
+++ b/index.md
@@ -12,7 +12,7 @@ Server | Description | Stats | Last Contact
 {% for node in sorted_nodes %}
 {% if node.automatic.roles contains "equinix" %}
 {% assign node_name = node.name | split: '.' | first %}
-[{{ node_name }}]({{ site.baseurl }}/servers/{{ node.name }}/) | {{ node.automatic.roles | server_description }} | [munin](http://munin.openstreetmap.org/openstreetmap/{{ node_name }}.openstreetmap/index.html) | {{ node.automatic.ohai_time | date_to_pretty }}
+[{{ node_name }}]({{ site.baseurl }}/servers/{{ node.name }}/) | {{ node.automatic.roles | server_description }} | [munin](http://munin.openstreetmap.org/openstreetmap.org/{{ node_name }}.openstreetmap.org/index.html) | {{ node.automatic.ohai_time | date_to_pretty }}
 {% endif %}
 {% endfor %}
 {% endstrip %}
@@ -25,7 +25,7 @@ Server | Description | Stats | Last Contact
 {% for node in sorted_nodes %}
 {% if node.automatic.roles contains "ucl" %}
 {% assign node_name = node.name | split: '.' | first %}
-[{{ node_name }}]({{ site.baseurl }}/servers/{{ node.name }}/) | {{ node.automatic.roles | server_description }} | [munin](http://munin.openstreetmap.org/openstreetmap/{{ node_name }}.openstreetmap/index.html) | {{ node.automatic.ohai_time | date_to_pretty }}
+[{{ node_name }}]({{ site.baseurl }}/servers/{{ node.name }}/) | {{ node.automatic.roles | server_description }} | [munin](http://munin.openstreetmap.org/openstreetmap.org/{{ node_name }}.openstreetmap.org/index.html) | {{ node.automatic.ohai_time | date_to_pretty }}
 {% endif %}
 {% endfor %}
 {% endstrip %}
@@ -38,7 +38,7 @@ Server | Description | Stats | Last Contact
 {% for node in sorted_nodes %}
 {% if node.automatic.roles contains "bytemark" %}
 {% assign node_name = node.name | split: '.' | first %}
-[{{ node_name }}]({{ site.baseurl }}/servers/{{ node.name }}/) | {{ node.automatic.roles | server_description }} | [munin](http://munin.openstreetmap.org/openstreetmap/{{ node_name }}.openstreetmap/index.html) | {{ node.automatic.ohai_time | date_to_pretty }}
+[{{ node_name }}]({{ site.baseurl }}/servers/{{ node.name }}/) | {{ node.automatic.roles | server_description }} | [munin](http://munin.openstreetmap.org/openstreetmap.org/{{ node_name }}.openstreetmap.org/index.html) | {{ node.automatic.ohai_time | date_to_pretty }}
 {% endif %}
 {% endfor %}
 {% endstrip %}
@@ -51,7 +51,7 @@ Server | Location | Country |Stats | Last Contact
 {% for node in sorted_nodes %}
 {% if node.automatic.roles contains "tilecache" %}
 {% assign node_name = node.name | split: '.' | first %}
-[{{ node_name }}]({{ site.baseurl }}/servers/{{ node.name }}/) | Hosted by {{ node.default.hosted_by | linkify: 'isps' }} in {{ node.default.location }} | <span class="flag-icon flag-icon-{{ node.override.country }}"></span> | [munin](http://munin.openstreetmap.org/openstreetmap/{{ node_name }}.openstreetmap/index.html) | {{ node.automatic.ohai_time | date_to_pretty }}
+[{{ node_name }}]({{ site.baseurl }}/servers/{{ node.name }}/) | Hosted by {{ node.default.hosted_by | linkify: 'isps' }} in {{ node.default.location }} | <span class="flag-icon flag-icon-{{ node.override.country }}"></span> | [munin](http://munin.openstreetmap.org/openstreetmap.org/{{ node_name }}.openstreetmap.org/index.html) | {{ node.automatic.ohai_time | date_to_pretty }}
 {% endif %}
 {% endfor %}
 {% endstrip %}
@@ -65,7 +65,7 @@ Server | Description | Location | Stats | Last Contact
 {% for node in sorted_nodes %}
 {% unless node.automatic.roles contains "equinix" or node.automatic.roles contains "ucl" or node.automatic.roles contains "bytemark" or node.automatic.roles contains "tilecache" %}
 {% assign node_name = node.name | split: '.' | first %}
-[{{ node_name }}]({{ site.baseurl }}/servers/{{ node.name }}/) | {{ node.automatic.roles | server_description }} | Hosted by {{ node.default.hosted_by | linkify: 'isps' }} in {{ node.default.location }} | [munin](http://munin.openstreetmap.org/openstreetmap/{{ node_name }}.openstreetmap/index.html) | {{ node.automatic.ohai_time | date_to_pretty }}
+[{{ node_name }}]({{ site.baseurl }}/servers/{{ node.name }}/) | {{ node.automatic.roles | server_description }} | Hosted by {{ node.default.hosted_by | linkify: 'isps' }} in {{ node.default.location }} | [munin](http://munin.openstreetmap.org/openstreetmap.org/{{ node_name }}.openstreetmap.org/index.html) | {{ node.automatic.ohai_time | date_to_pretty }}
 {% endunless %}
 {% endfor %}
 {% endstrip %}


### PR DESCRIPTION
This is should fix the munin links in response to the change below (from @tomhughes) which moved most servers in munin from openstreetmap to openstreetmap.org:

https://git.openstreetmap.org/chef.git/commitdiff/27fd498
