### PR TITLE
Commit to fix rhaegal attirbution

### DIFF
--- a/_data/additional_thanks.yml
+++ b/_data/additional_thanks.yml
@@ -1,2 +1,3 @@
 eddie: Thanks to American Red Cross for donating this server.
 pyrene: Thanks to OpenStreetMap US for providing this server.
+rhaegal: Thanks to OpenIT for providing this server.

--- a/_data/thanks.yml
+++ b/_data/thanks.yml
@@ -3,4 +3,4 @@ katie: Freerk Ohling
 keizer: Schwarzer IT
 konqi: Freerk Ohling
 naga: Dorian
-rhaegal: Faculty of Geodesy, University of Zagreb and OpenIT
+rhaegal: Faculty of Geodesy, University of Zagreb

--- a/_data/urls.yml
+++ b/_data/urls.yml
@@ -123,7 +123,7 @@ isps:
   Freerk Ohling: https://www.ohling.org/
   Freifunk Rheinland: https://www.freifunk-rheinland.net/
   G5 Solutions: http://www.g5solutions.id/
-  GEOF: http://www.geof.unizg.hr/
+  Faculty of Geodesy, University of Zagreb: http://www.geof.unizg.hr/
   Grifon: https://grifon.fr/
   GRNET: https://grnet.gr/
   Hetzner: https://www.hetzner.de/


### PR DESCRIPTION
Hope this is everything needed to fix attribution.
Server is hosted at Faculty of Geodesy, University of Zagreb. CARNet is just their ISP in this case.
Server was donated by OpenIT(SSD's from OSMF).