### PR TITLE
Clean up old ISPs

### DIFF
--- a/_data/thanks.yml
+++ b/_data/thanks.yml
@@ -1,8 +1,1 @@
-cmok: Komяpa
-katie: Freerk Ohling
-keizer: Schwarzer IT
-kilgharrah: FOSSGIS
-kokosnuss: Max Michels
-konqi: Freerk Ohling
 rhaegal: Faculty of Geodesy, University of Zagreb
-tuatara: smith.geek.nz

--- a/_data/urls.yml
+++ b/_data/urls.yml
@@ -141,58 +141,22 @@ oobs:
 isps:
   AARNet: https://www.aarnet.edu.au/
   Academic Computer Club, Umeå University: https://www.acc.umu.se/
-  AltaVoz: https://www.altavoz.net/
   Appliwave: https://www.appliwave.com/
   AWS: https://aws.amazon.com/
   Blix Solutions: https://www.blix.com/
   Bluehost: https://www.bluehost.com/
   Bytemark: https://www.bytemark.co.uk/
   CARNet: https://www.carnet.hr/en
-  Catalyst: https://www.catalyst.net.nz/
-  Centro de Computação Científica e Software Livre, Universidade Federal do Paraná: https://www.c3sl.ufpr.br/
-  DataHata: https://www.datahata.by/
-  Delta Telecom: https://www.delta-telecom.net/
-  dotsrc.org: https://dotsrc.org/
-  EdgeUno: https://www.edgeuno.com/
-  EUserv: https://www.euserv.com/
   Exonetric: https://www.exonetric.com/
-  FAImaison: https://www.faimaison.net/
-  FOSSGIS: https://www.fossgis.de/
-  Freerk Ohling: https://www.ohling.org/
-  Freifunk Rheinland: https://www.freifunk-rheinland.net/
-  FullSave: https://www.fullsave.com/
-  G5 Solutions: http://www.g5solutions.id/
   Gandi: https://www.gandi.net/
   Faculty of Geodesy, University of Zagreb: http://www.geof.unizg.hr/
-  greenminihost: https://www.greenminihost.com/
-  Grifon: https://grifon.fr/
-  GRNET: https://grnet.gr/
-  Hetzner: https://www.hetzner.de/
-  HostedIn.NZ: https://hostedin.nz/
-  iWay: https://www.iway.ch/
-  Jump Networks: http://www.jump.net.uk/
   INX-ZA: https://ispa.org.za/inx/
-  Komяpa: http://komzpa.net/
   LyonIX: https://www.lyonix.net/
-  Lysator: https://www.lysator.liu.se/
-  Max Michels: https://twitter.com/max_michels_
-  MilkyWan: https://milkywan.fr/
-  NCHC: https://www.nchc.org.tw/en/
   NetAlerts: http://www.netalerts.org/
   OpenIT: https://www.openit.hr/
   OSUOSL: https://osuosl.org/
   OVH: https://www.ovh.co.uk/
-  prgmr.com: https://prgmr.com/
-  ProxGroup: https://www.proxgroup.fr/
   Scaleway: https://www.scaleway.com/
-  Schwarzer IT: https://twitter.com/andre_schwarzer
-  szerverem.hu: https://szerverem.hu/
   TeraSwitch Networks: https://teraswitch.com/
-  Tetaneutral.net: https://tetaneutral.net/
   Teleservice Skåne AB: https://www.teleservice.net/
-  Tuxis: https://www.tuxis.nl/
-  Ukrainian Telecommunication Group: https://utelecom.com.ua/
   Université de Pau et des Pays de l'Adour: https://www.univ-pau.fr/
-  University of West Bohemia: https://www.zcu.cz/
-  University of Zaragoza: https://unizar.es/
-  Yandex: https://www.yandex.ru/


### PR DESCRIPTION
These ISPs used to host cache nodes, but no longer host any OSMF infrastructure.