### PR TITLE
Add system name to index

### DIFF
--- a/index.md
+++ b/index.md
@@ -7,12 +7,13 @@ layout: default
 ## [Equinix Amsterdam](#equinix-amsterdam)
 
 {% strip %}
-Server | Description | Stats | Last Contact
+Server | Description | System | Stats | Last Contact
 -------|-------------|-------|-------------
 {% for node in sorted_nodes %}
 {% if node.automatic.roles contains "equinix-ams" %}
 {% assign node_name = node.name | split: '.' | first %}
-[{{ node_name }}]({{ site.baseurl }}/servers/{{ node.name }}/) | {{ node.automatic.roles | server_description }} | [prometheus](https://prometheus.openstreetmap.org/d/Ea3IUVtMz/host-overview?orgId=1&var-instance={{ node_name }}) | {{ node.automatic.ohai_time | date_to_pretty }}
+{% assign node_system =  node.automatic.dmi.system.manufacturer  | append: ' ' | append: node.automatic.dmi.system.product_name | strip %}
+[{{ node_name }}]({{ site.baseurl }}/servers/{{ node.name }}/) | {{ node.automatic.roles | server_description }} | {{ node_system }} | [prometheus](https://prometheus.openstreetmap.org/d/Ea3IUVtMz/host-overview?orgId=1&var-instance={{ node_name }}) | {{ node.automatic.ohai_time | date_to_pretty }}
 {% endif %}
 {% endfor %}
 {% endstrip %}
@@ -20,12 +21,13 @@ Server | Description | Stats | Last Contact
 ## [Equinix Dublin](#equinix-dublin)
 
 {% strip %}
-Server | Description | Stats | Last Contact
+Server | Description | System | Stats | Last Contact
 -------|-------------|-------|-------------
 {% for node in sorted_nodes %}
 {% if node.automatic.roles contains "equinix-dub" %}
 {% assign node_name = node.name | split: '.' | first %}
-[{{ node_name }}]({{ site.baseurl }}/servers/{{ node.name }}/) | {{ node.automatic.roles | server_description }} | [prometheus](https://prometheus.openstreetmap.org/d/Ea3IUVtMz/host-overview?orgId=1&var-instance={{ node_name }}) | {{ node.automatic.ohai_time | date_to_pretty }}
+{% assign node_system =  node.automatic.dmi.system.manufacturer  | append: ' ' | append: node.automatic.dmi.system.product_name | strip %}
+[{{ node_name }}]({{ site.baseurl }}/servers/{{ node.name }}/) | {{ node.automatic.roles | server_description }} | {{ node_system }} | [prometheus](https://prometheus.openstreetmap.org/d/Ea3IUVtMz/host-overview?orgId=1&var-instance={{ node_name }}) | {{ node.automatic.ohai_time | date_to_pretty }}
 {% endif %}
 {% endfor %}
 {% endstrip %}
@@ -33,12 +35,13 @@ Server | Description | Stats | Last Contact
 ## [University College London](#university-college-london)
 
 {% strip %}
-Server | Description | Stats | Last Contact
+Server | Description | System | Stats | Last Contact
 -------|-------------|-------|-------------
 {% for node in sorted_nodes %}
 {% if node.automatic.roles contains "ucl" %}
 {% assign node_name = node.name | split: '.' | first %}
-[{{ node_name }}]({{ site.baseurl }}/servers/{{ node.name }}/) | {{ node.automatic.roles | server_description }} | [prometheus](https://prometheus.openstreetmap.org/d/Ea3IUVtMz/host-overview?orgId=1&var-instance={{ node_name }}) | {{ node.automatic.ohai_time | date_to_pretty }}
+{% assign node_system =  node.automatic.dmi.system.manufacturer  | append: ' ' | append: node.automatic.dmi.system.product_name | strip %}
+[{{ node_name }}]({{ site.baseurl }}/servers/{{ node.name }}/) | {{ node.automatic.roles | server_description }} | {{ node_system }} | [prometheus](https://prometheus.openstreetmap.org/d/Ea3IUVtMz/host-overview?orgId=1&var-instance={{ node_name }}) | {{ node.automatic.ohai_time | date_to_pretty }}
 {% endif %}
 {% endfor %}
 {% endstrip %}
@@ -46,12 +49,13 @@ Server | Description | Stats | Last Contact
 ## [Other](#other)
 
 {% strip %}
-Server | Description | Location | Stats | Last Contact
+Server | Description | Location | System | Stats | Last Contact
 -------|-------------|----------|-------|-------------
 {% for node in sorted_nodes %}
 {% unless node.automatic.roles contains "equinix-ams" or node.automatic.roles contains "equinix-dub" or node.automatic.roles contains "ucl" %}
 {% assign node_name = node.name | split: '.' | first %}
-[{{ node_name }}]({{ site.baseurl }}/servers/{{ node.name }}/) | {{ node.automatic.roles | server_description }} | Hosted by {{ node.default.hosted_by | linkify: 'isps' }} in {{ node.default.location }} | [prometheus](https://prometheus.openstreetmap.org/d/Ea3IUVtMz/host-overview?orgId=1&var-instance={{ node_name }}) | {{ node.automatic.ohai_time | date_to_pretty }}
+{% assign node_system =  node.automatic.dmi.system.manufacturer  | append: ' ' | append: node.automatic.dmi.system.product_name | strip %}
+[{{ node_name }}]({{ site.baseurl }}/servers/{{ node.name }}/) | {{ node.automatic.roles | server_description }} | Hosted by {{ node.default.hosted_by | linkify: 'isps' }} in {{ node.default.location }} | {{ node_system }} | [prometheus](https://prometheus.openstreetmap.org/d/Ea3IUVtMz/host-overview?orgId=1&var-instance={{ node_name }}) | {{ node.automatic.ohai_time | date_to_pretty }}
 {% endunless %}
 {% endfor %}
 {% endstrip %}

--- a/index.md
+++ b/index.md
@@ -8,7 +8,7 @@ layout: default
 
 {% strip %}
 Server | Description | System | Stats | Last Contact
--------|-------------|-------|-------------
+-------|-------------|--------|-------|-------------
 {% for node in sorted_nodes %}
 {% if node.automatic.roles contains "equinix-ams" %}
 {% assign node_name = node.name | split: '.' | first %}
@@ -22,7 +22,7 @@ Server | Description | System | Stats | Last Contact
 
 {% strip %}
 Server | Description | System | Stats | Last Contact
--------|-------------|-------|-------------
+-------|-------------|--------|-------|-------------
 {% for node in sorted_nodes %}
 {% if node.automatic.roles contains "equinix-dub" %}
 {% assign node_name = node.name | split: '.' | first %}
@@ -36,7 +36,7 @@ Server | Description | System | Stats | Last Contact
 
 {% strip %}
 Server | Description | System | Stats | Last Contact
--------|-------------|-------|-------------
+-------|-------------|--------|-------|-------------
 {% for node in sorted_nodes %}
 {% if node.automatic.roles contains "ucl" %}
 {% assign node_name = node.name | split: '.' | first %}
@@ -50,7 +50,7 @@ Server | Description | System | Stats | Last Contact
 
 {% strip %}
 Server | Description | Location | System | Stats | Last Contact
--------|-------------|----------|-------|-------------
+-------|-------------|----------|--------|-------|-------------
 {% for node in sorted_nodes %}
 {% unless node.automatic.roles contains "equinix-ams" or node.automatic.roles contains "equinix-dub" or node.automatic.roles contains "ucl" %}
 {% assign node_name = node.name | split: '.' | first %}


### PR DESCRIPTION
Add a new column to index containing Manufacturer (eg: HPE) and Product Name (eg: DL360 Gen10)

The style doesn't 100% match that `_plugins/server_generator.rb` but close enough to be useful.

Screenshot:

<img width="773" alt="Screenshot 2023-07-31 at 17 27 35" src="https://github.com/osmfoundation/osmf-server-info/assets/248188/9ee3e645-0b2a-4338-ba34-e2ec68875c30">
